### PR TITLE
Add GraphHopper Attribution

### DIFF
--- a/app/src/main/java/graphhopper/com/graphhopper_navigation_example/GHAttributionDialogManager.java
+++ b/app/src/main/java/graphhopper/com/graphhopper_navigation_example/GHAttributionDialogManager.java
@@ -2,10 +2,15 @@ package graphhopper.com.graphhopper_navigation_example;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.view.View;
 import android.widget.ArrayAdapter;
+import android.widget.Toast;
 
 import com.mapbox.mapboxsdk.attribution.Attribution;
 import com.mapbox.mapboxsdk.attribution.AttributionParser;
@@ -50,6 +55,30 @@ public class GHAttributionDialogManager extends AttributionDialogManager {
         }
     }
 
+    // Called when someone selects an attribution or telemetry settings from the dialog
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+        showMapFeedbackWebPage(which);
+    }
+
+    private void showMapFeedbackWebPage(int which) {
+        Attribution[] attributions = attributionSet.toArray(new Attribution[attributionSet.size()]);
+        String url = attributions[which].getUrl();
+        showWebPage(url);
+    }
+
+    private void showWebPage(@NonNull String url) {
+        try {
+            Intent intent = new Intent(Intent.ACTION_VIEW);
+            intent.setData(Uri.parse(url));
+            context.startActivity(intent);
+        } catch (ActivityNotFoundException exception) {
+            // explicitly handling if the device hasn't have a web browser installed. #8899
+            Toast.makeText(context, R.string.error_no_browser_installed, Toast.LENGTH_LONG).show();
+        }
+    }
+
+
     protected void showAttributionDialog(String[] attributionTitles) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         builder.setTitle(R.string.app_name);
@@ -76,7 +105,7 @@ public class GHAttributionDialogManager extends AttributionDialogManager {
 
         private Set<Attribution> build() {
             List<String> attributions = new ArrayList<>();
-            attributions.add("<a href=\"https://www.graphhopper.com/\" target=\"_blank\">Powered by GraphHopper API</a>");
+            attributions.add("<a href=\"https://www.graphhopper.com/\" target=\"_blank\">&copy; GraphHopper API</a>");
             for (Source source : mapboxMap.getSources()) {
                 attributions.add(source.getAttribution());
             }

--- a/app/src/main/java/graphhopper/com/graphhopper_navigation_example/GHAttributionDialogManager.java
+++ b/app/src/main/java/graphhopper/com/graphhopper_navigation_example/GHAttributionDialogManager.java
@@ -76,7 +76,7 @@ public class GHAttributionDialogManager extends AttributionDialogManager {
 
         private Set<Attribution> build() {
             List<String> attributions = new ArrayList<>();
-            attributions.add("<a href=\"https://www.graphhopper.com/\" target=\"_blank\">&copy; GraphHopper</a>");
+            attributions.add("<a href=\"https://www.graphhopper.com/\" target=\"_blank\">Powered by GraphHopper API</a>");
             for (Source source : mapboxMap.getSources()) {
                 attributions.add(source.getAttribution());
             }
@@ -85,7 +85,6 @@ public class GHAttributionDialogManager extends AttributionDialogManager {
                     .withCopyrightSign(true)
                     // TODO when using Mapbox as Tilesource we should keep this, should we automatically remove it otherwise?
                     .withImproveMap(true)
-                    .withTelemetryAttribution(true)
                     .withAttributionData(attributions.toArray(new String[attributions.size()]))
                     .build().getAttributions();
         }

--- a/app/src/main/java/graphhopper/com/graphhopper_navigation_example/GHAttributionDialogManager.java
+++ b/app/src/main/java/graphhopper/com/graphhopper_navigation_example/GHAttributionDialogManager.java
@@ -1,0 +1,93 @@
+package graphhopper.com.graphhopper_navigation_example;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.ArrayAdapter;
+
+import com.mapbox.mapboxsdk.attribution.Attribution;
+import com.mapbox.mapboxsdk.attribution.AttributionParser;
+import com.mapbox.mapboxsdk.maps.AttributionDialogManager;
+import com.mapbox.mapboxsdk.maps.MapboxMap;
+import com.mapbox.mapboxsdk.style.sources.Source;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * This class is mostly based on {@link AttributionDialogManager}, but adds GraphHopper as
+ * additional attribution.
+ */
+public class GHAttributionDialogManager extends AttributionDialogManager {
+
+    private final Context context;
+    private final MapboxMap mapboxMap;
+    private Set<Attribution> attributionSet;
+
+    public GHAttributionDialogManager(@NonNull Context context, @NonNull MapboxMap mapboxMap) {
+        super(context, mapboxMap);
+        this.context = context;
+        this.mapboxMap = mapboxMap;
+    }
+
+    // Called when someone presses the attribution icon on the map
+    @Override
+    public void onClick(View view) {
+        attributionSet = new GHAttributionDialogManager.AttributionBuilder(mapboxMap).build();
+
+        boolean isActivityFinishing = false;
+        if (context instanceof Activity) {
+            isActivityFinishing = ((Activity) context).isFinishing();
+        }
+
+        // check is hosting activity isn't finishing
+        // https://github.com/mapbox/mapbox-gl-native/issues/11238
+        if (!isActivityFinishing) {
+            showAttributionDialog(getAttributionTitles());
+        }
+    }
+
+    protected void showAttributionDialog(String[] attributionTitles) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setTitle(R.string.app_name);
+        builder.setAdapter(new ArrayAdapter<>(context, R.layout.attribution_list_item, attributionTitles), this);
+        builder.show();
+    }
+
+    private String[] getAttributionTitles() {
+        List<String> titles = new ArrayList<>();
+        for (Attribution attribution : attributionSet) {
+            titles.add(attribution.getTitle());
+        }
+        return titles.toArray(new String[titles.size()]);
+    }
+
+
+    private static class AttributionBuilder {
+
+        private final MapboxMap mapboxMap;
+
+        AttributionBuilder(MapboxMap mapboxMap) {
+            this.mapboxMap = mapboxMap;
+        }
+
+        private Set<Attribution> build() {
+            List<String> attributions = new ArrayList<>();
+            attributions.add("<a href=\"https://www.graphhopper.com/\" target=\"_blank\">&copy; GraphHopper</a>");
+            for (Source source : mapboxMap.getSources()) {
+                attributions.add(source.getAttribution());
+            }
+
+            return new AttributionParser.Options()
+                    .withCopyrightSign(true)
+                    // TODO when using Mapbox as Tilesource we should keep this, should we automatically remove it otherwise?
+                    .withImproveMap(true)
+                    .withTelemetryAttribution(true)
+                    .withAttributionData(attributions.toArray(new String[attributions.size()]))
+                    .build().getAttributions();
+        }
+    }
+}

--- a/app/src/main/java/graphhopper/com/graphhopper_navigation_example/NavigationLauncherActivity.java
+++ b/app/src/main/java/graphhopper/com/graphhopper_navigation_example/NavigationLauncherActivity.java
@@ -94,8 +94,8 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Telemetry.disableOnUserRequest();
         Mapbox.getInstance(this.getApplicationContext(), getString(R.string.mapbox_access_token));
+        Telemetry.disableOnUserRequest();
         setContentView(R.layout.activity_navigation_launcher);
         ButterKnife.bind(this);
         mapView.onCreate(savedInstanceState);

--- a/app/src/main/java/graphhopper/com/graphhopper_navigation_example/NavigationLauncherActivity.java
+++ b/app/src/main/java/graphhopper/com/graphhopper_navigation_example/NavigationLauncherActivity.java
@@ -37,6 +37,7 @@ import com.mapbox.mapboxsdk.geometry.LatLngBounds;
 import com.mapbox.mapboxsdk.maps.MapView;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
 import com.mapbox.mapboxsdk.maps.OnMapReadyCallback;
+import com.mapbox.mapboxsdk.maps.Telemetry;
 import com.mapbox.mapboxsdk.plugins.locationlayer.LocationLayerPlugin;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 import com.mapbox.services.android.navigation.ui.v5.NavigationLauncher;
@@ -93,6 +94,7 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        Telemetry.disableOnUserRequest();
         Mapbox.getInstance(this.getApplicationContext(), getString(R.string.mapbox_access_token));
         setContentView(R.layout.activity_navigation_launcher);
         ButterKnife.bind(this);

--- a/app/src/main/java/graphhopper/com/graphhopper_navigation_example/NavigationLauncherActivity.java
+++ b/app/src/main/java/graphhopper/com/graphhopper_navigation_example/NavigationLauncherActivity.java
@@ -215,6 +215,7 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
     @Override
     public void onMapReady(MapboxMap mapboxMap) {
         this.mapboxMap = mapboxMap;
+        this.mapboxMap.getUiSettings().setAttributionDialogManager(new GHAttributionDialogManager(this.mapView.getContext(), this.mapboxMap));
         this.mapboxMap.setOnMapLongClickListener(this);
         initLocationEngine();
         initLocationLayer();

--- a/app/src/main/res/layout/activity_navigation_launcher.xml
+++ b/app/src/main/res/layout/activity_navigation_launcher.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
+    <!-- If you use the Mapbox Tilesource, you need to set uiLogo=true - see https://www.mapbox.com/help/how-attribution-works/ -->
     <com.mapbox.mapboxsdk.maps.MapView
         android:id="@+id/mapView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        app:mapbox_uiAttribution="false" />
+        app:mapbox_uiAttribution="true"
+        app:mapbox_uiAttributionMarginLeft="5dp"
+        app:mapbox_uiLogo="false" />
 
     <ProgressBar
         android:id="@+id/loading"

--- a/app/src/main/res/layout/attribution_list_item.xml
+++ b/app/src/main/res/layout/attribution_list_item.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@android:id/text1"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:paddingLeft="24dp"
+    android:paddingRight="24dp"
+    android:textAllCaps="true"
+    android:textAppearance="?android:attr/textAppearanceButton"
+    android:textColor="@color/mapbox_blue"
+    android:textIsSelectable="false" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <string name="app_name" tools:override="true">GH Navigation Example</string>
+    <string name="app_name" tools:override="true">GraphHopper Demo</string>
 
     <string name="title_navigation_launcher">Navigation Sample</string>
     <string name="description_navigation_launcher">Showing basic navigation with multiple waypoints</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,5 +22,6 @@
     <string name="error_select_longer_route">Please select a longer route</string>
     <string name="error_valid_route_not_found">Valid route not found.</string>
     <string name="error_calculating_route">There was an error calculating the route</string>
+    <string name="error_no_browser_installed">No browser installed</string>
     <string name="explanation_long_press_waypoint">Long press map to place waypoint</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
-<resources>
-    <string name="app_name">GH Nav Sample</string>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="app_name" tools:override="true">GH Navigation Example</string>
 
     <string name="title_navigation_launcher">Navigation Sample</string>
     <string name="description_navigation_launcher">Showing basic navigation with multiple waypoints</string>


### PR DESCRIPTION
This PR adds attribution for GraphHopper to the Map. Fixes #3.

Unfortunately the Mapbox SDK makes this rather hard. That's why we had to extend the AttributionDialogManager. I wasn't able to register GH as a Source in the map.