### PR TITLE
Send bearing for regular route request

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-navigation-ui:0.18.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-navigation-ui:0.19.0'
     implementation 'com.graphhopper:directions-api-client:0.10.1-4'
     implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'


### PR DESCRIPTION
This PR allows sending the bearing for regular route requests.

Also I updated the mapbox-sdk dependency and removed the wayname chips. Wayname chips seem to require a Mapbox access key.