### PR TITLE
Add nav native

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.mapbox.mapboxsdk:mapbox-android-navigation-ui:0.18.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-android-navigation-ui:0.22.0'
     implementation 'com.graphhopper:directions-api-client:0.10.1-4'
     implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -19,6 +19,7 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven { url 'https://mapbox.bintray.com/mapbox' }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Aug 22 16:03:18 CEST 2018
+#Thu Oct 04 09:25:03 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
This PR updates the mapbox-navigation-ui dependency to the latest version. This version contains the closed source nav native library. 

While the current version adds a lot of benefits and fixes a lot of issues I have seen a couple of new issues as well. There are cases where `simulate route` stops working and the position is not updated anymore, I recommend to use [Lockito](https://play.google.com/store/apps/details?id=fr.dvilleneuve.lockito) for testing instead. I have also seen cases where my GPS position hasn't been updated in a real life test and I needed to restart the app. These findings need further testing though.

BTW: With mapbox-android-navigation-ui:0.22.0` there is a new way of requesting the location from the SDK, that's why there are changes with the `locationLayer`. My findings above could be connected to this and might be fixed in the next version.
BTW2: there are some minor side changes that I don't think require a separate PR, if you think differently, let me know, then I will split them up into separate PRs.