### PR TITLE
Allow to set start different from the current location

### DIFF
--- a/app/src/main/java/com/graphhopper/navigation/example/NavigationLauncherActivity.java
+++ b/app/src/main/java/com/graphhopper/navigation/example/NavigationLauncherActivity.java
@@ -234,8 +234,10 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
         waypoints.clear();
         mapRoute.removeRoute();
         route = null;
-        if (currentMarker != null)
-            currentMarker.remove();
+        if (currentMarker != null) {
+            mapboxMap.removeMarker(currentMarker);
+            currentMarker = null;
+        }
 
         clearGeocodingResults();
     }
@@ -243,7 +245,7 @@ public class NavigationLauncherActivity extends AppCompatActivity implements OnM
     public void clearGeocodingResults() {
         if (markers != null) {
             for (Marker marker : markers) {
-                marker.remove();
+                this.mapboxMap.removeMarker(marker);
             }
             markers.clear();
         }

--- a/app/src/main/res/layout/activity_navigation_launcher.xml
+++ b/app/src/main/res/layout/activity_navigation_launcher.xml
@@ -19,6 +19,6 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:indeterminate="true"
-        android:visibility="visible" />
+        android:visibility="invisible" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,10 @@
     <string name="error_location_not_found">Location not found</string>
     <string name="error_geocoding_no_location">No location found</string>
     <string name="error_too_many_waypoints">A route cannot have more than 25 waypoints</string>
+    <string name="error_not_enough_waypoints">A route needs at least 2 waypoints</string>
     <string name="error_no_browser_installed">No browser installed</string>
+    <string name="error_too_far_from_start_title">Too far from start</string>
+    <string name="error_too_far_from_start_message">Would you like to recalculate the route from your current location?</string>
     <string name="explanation_long_press_waypoint">Long press map to place waypoint</string>
     <string name="launch_navigation">Launch Navigation</string>
     <string name="reset_route">Reset Route</string>


### PR DESCRIPTION
This PR allows to set starts different from the current location and fixes #19.

If you want to start the navigation and are too far away (100 m) from the route start, the app will ask you if you would like to recalculate the route from your current start. You can ignore this and just start as planned, then the SDK might decide to recalculate the route or not (also depends if you choose to simulate the route or not - which works fine).