### PR TITLE
Add the gh vehicles to the app

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -32,12 +32,24 @@
     <string-array name="route_profile_array">
         <item>Driving</item>
         <item>Cycling</item>
+        <item>MTB</item>
+        <item>Racing bike</item>
         <item>Walking</item>
+        <item>Hike</item>
+        <item>Scooter</item>
+        <item>Small truck</item>
+        <item>Truck</item>
     </string-array>
 
     <string-array name="route_profile_values_array">
         <item>driving</item>
         <item>cycling</item>
+        <item>mtb</item>
+        <item>racingbike</item>
         <item>walking</item>
+        <item>hike</item>
+        <item>scooter</item>
+        <item>small_truck</item>
+        <item>truck</item>
     </string-array>
 </resources>


### PR DESCRIPTION
This PR fixes #42. This makes it possible to use for example the truck vehicle in the app.